### PR TITLE
起動スクリプトのJARのバージョン番号を指定するように修正 #5

### DIFF
--- a/.github/dist/tkfm
+++ b/.github/dist/tkfm
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./jre/bin/java -jar tkfm.jar com.jiro4989.tkfm.Main
+./jre/bin/java -jar tkfm-{tag}.jar com.jiro4989.tkfm.Main

--- a/.github/dist/tkfm.bat
+++ b/.github/dist/tkfm.bat
@@ -1,3 +1,3 @@
 @echo off
 
-.\jre\bin\java.exe -jar .\tkfm.jar com.jiro4989.tkfm.Main
+.\jre\bin\java.exe -jar .\tkfm-{tag}.jar com.jiro4989.tkfm.Main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,9 +81,11 @@ jobs:
           cp -r .github/dist/* LICENSE build/libs/tkfm.jar jre tkfm_${os_name}/
           mkdir dist
           if [ ${os_name} = windows ]; then
+            sed -i "s/{tag}/${GITHUB_REF##*/}/g" tkfm_${os_name}/tkfm.bat
             7z a tkfm_${os_name}.zip tkfm_${os_name}
             mv tkfm_${os_name}.zip dist/
           else
+            sed -i "s/{tag}/${GITHUB_REF##*/}/g" tkfm_${os_name}/tkfm
             tar czf tkfm_${os_name}.tar.gz tkfm_${os_name}
             mv tkfm_${os_name}.tar.gz dist/
           fi


### PR DESCRIPTION
build.gradleに`version`を指定するようにしたら
生成されるjarにもバージョン番号が含まれるようになった。
せっかくなのでそのまま使う。