### PR TITLE
chore: build.gradleを整理した #51

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,10 +51,10 @@ dependencies {
   implementation 'com.google.guava:guava:28.2-jre'
 
   // Use JUnit test framework
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.6.2'
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.2'
-  testImplementation group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.6.2'
-  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.6.2'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
+  testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.2'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.6.2'
   testImplementation "org.testfx:testfx-junit5:4.0.16-alpha"
 
   // JavaFX

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ def appMods = [
 ]
 
 def jmodsDir = './jmods/javafx-jmods-11.0.2'
-def customJREDir = 'jre'
+def CUSTOM_JRE_DIR = 'jre'
 
 repositories {
   mavenCentral()
@@ -220,7 +220,7 @@ if (project.hasProperty('CI_JMODS_DIR')) {
 
 task clearCustomJRE {
   doLast {
-    delete customJREDir
+    delete CUSTOM_JRE_DIR
   }
 }
 
@@ -231,7 +231,7 @@ task jlink(type: Exec) {
       '--module-path', jmodsDir,
       '--add-modules', appMods.join(','),
       '--compress=2',
-      '--output', customJREDir
+      '--output', CUSTOM_JRE_DIR
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,9 @@ jacoco {
 }
 
 tasks.register('junitPlatformJacocoReport', JacocoReport) {
+  group = "Verification"
+  description = "Jacocoを使ってテストのレポートを取得する"
+
   sourceSets sourceSets.main
   executionData junitPlatformTest
 }
@@ -174,6 +177,9 @@ if (project.hasProperty('CI_COMMIT_HASH')) {
 // CIでのビルド時にはタグ番号とコミットハッシュが埋め込まれる。
 // こうすることでタグ番号の二重管理を防ぐことができる。
 tasks.register('versionSet', Copy) {
+  group = "Build"
+  description = "ソースコードにビルド時のタグバージョンとコミットハッシュ値を埋め込む"
+
   from SRC_FILE
   into DST_DIR
   expand(version: version, commitHash: commitHash)
@@ -184,6 +190,9 @@ tasks.register('versionSet', Copy) {
 }
 
 tasks.register('clearDependencies') {
+  group = "Build"
+  description = "依存ライブラリを削除する"
+
   doLast {
     delete LIB_DIR
   }
@@ -193,6 +202,9 @@ tasks.register('clearDependencies') {
 //
 // runAppで実行するときにライブラリのパスを指定するために使用する。
 tasks.register('dumpDependencies') {
+  group = "Build"
+  description = "依存ライブラリjarをlib配下にコピーする"
+
   doLast {
     configurations.compileClasspath.each {
       def jarFile = it.absolutePath
@@ -205,6 +217,9 @@ tasks.register('dumpDependencies') {
 }
 
 tasks.register('runApp', Exec) {
+  group = "Application"
+  description = "アプリケーションを起動する"
+
   doLast {
     commandLine 'java',
       '--module-path', LIB_DIR,
@@ -218,6 +233,9 @@ if (project.hasProperty('CI_JMODS_DIR')) {
 }
 
 tasks.register('clearCustomJRE') {
+  group = "Build"
+  description = "生成したカスタムJREを削除する"
+
   doLast {
     delete CUSTOM_JRE_DIR
   }
@@ -225,6 +243,9 @@ tasks.register('clearCustomJRE') {
 
 // カスタムJREを作成する。
 tasks.register('jlink', Exec) {
+  group = "Build"
+  description = "jlinkを使ってカスタムJREを作成する"
+
   commandLine 'jlink',
     '--module-path', jmodsDir,
     '--add-modules', APP_MODS.join(','),
@@ -232,14 +253,7 @@ tasks.register('jlink', Exec) {
     '--output', CUSTOM_JRE_DIR
 }
 
-/*
- 実行順序の明示
- clean -> spotlessApply -+-> versionSet -> compileJava
- |
- +-> test -> jacocoTestReport
- clearDependencies -> dumpDependencies -> runApp
- clearCustomJRE -> jlink
- */
+// 実行順序の明示
 spotlessApply.dependsOn(['clean'])
 versionSet.dependsOn(['spotlessApply'])
 test.dependsOn('spotlessApply')

--- a/build.gradle
+++ b/build.gradle
@@ -100,10 +100,6 @@ jar {
   duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
-test {
-  finalizedBy jacocoTestReport
-}
-
 jacoco {
   applyTo junitPlatformTest
 }
@@ -170,13 +166,6 @@ task versionSet(type: Copy) {
   expand(version: version, commitHash: commitHash)
 }
 
-// 実行順序の明示
-// clean -> spotlessApply (code format) -> [ versionSet -> compileJava | test ]
-spotlessApply.dependsOn(['clean'])
-versionSet.dependsOn(['spotlessApply'])
-test.dependsOn('spotlessApply')
-compileJava.dependsOn(['versionSet'])
-
 def libDir = './lib'
 
 task clearDependencies {
@@ -186,7 +175,7 @@ task clearDependencies {
 // dependenciesで取得したjarファイルをlib配下にコピーする。
 //
 // runAppで実行するときにライブラリのパスを指定するために使用する。
-task dumpDependencies(dependsOn: clearDependencies) {
+task dumpDependencies {
   doLast {
     configurations.compileClasspath.each {
       def jarFile = it.absolutePath
@@ -206,7 +195,7 @@ def appMods = [
   'javafx.fxml',
 ]
 
-task runApp(type: Exec, dependsOn: dumpDependencies) {
+task runApp(type: Exec) {
   commandLine 'java',
     '--module-path', libDir,
     '--add-modules', appMods.join(','),
@@ -225,10 +214,33 @@ task clearCustomJRE {
 }
 
 // カスタムJREを作成する。
-task jlink(type: Exec, dependsOn: clearCustomJRE) {
+task jlink(type: Exec) {
   commandLine 'jlink',
     '--module-path', jmodsDir,
     '--add-modules', appMods.join(','),
     '--compress=2',
     '--output', customJREDir
 }
+
+/*
+実行順序の明示
+
+clean -> spotlessApply -+-> versionSet -> compileJava
+                        |
+                        +-> test -> jacocoTestReport
+
+clearDependencies -> dumpDependencies -> runApp
+
+clearCustomJRE -> jlink
+
+*/
+spotlessApply.dependsOn(['clean'])
+versionSet.dependsOn(['spotlessApply'])
+test.dependsOn('spotlessApply')
+compileJava.dependsOn(['versionSet'])
+jacocoTestReport.dependsOn(['test'])
+
+dumpDependencies.dependsOn(['clearDependencies'])
+runApp.dependsOn(['dumpDependencies'])
+
+jlink.dependsOn(['clearCustomJRE'])

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,6 @@
  */
 
 buildscript {
-  ext.javafx_version = '16'
-
   repositories {
     mavenCentral()
     maven {
@@ -82,11 +80,11 @@ dependencies {
   testImplementation "org.testfx:testfx-junit5:4.0.16-alpha"
 
   // JavaFX
-  implementation "org.openjfx:javafx-fxml:$javafx_version"
-  implementation "org.openjfx:javafx-base:$javafx_version"
-  implementation "org.openjfx:javafx-controls:$javafx_version"
-  implementation "org.openjfx:javafx-graphics:$javafx_version"
-  implementation "org.openjfx:javafx-swing:$javafx_version"
+  implementation "org.openjfx:javafx-fxml:16"
+  implementation "org.openjfx:javafx-base:16"
+  implementation "org.openjfx:javafx-controls:16"
+  implementation "org.openjfx:javafx-graphics:16"
+  implementation "org.openjfx:javafx-swing:16"
 }
 
 sourceCompatibility = 16

--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,7 @@ tasks.register('versionSet', Copy) {
   }
 }
 
-tasks.register('clearDependencies') {
+tasks.register('cleanDependencies') {
   group = "Build"
   description = "依存ライブラリを削除する"
 
@@ -232,7 +232,7 @@ if (project.hasProperty('CI_JMODS_DIR')) {
   jmodsDir = CI_JMODS_DIR
 }
 
-tasks.register('clearCustomJRE') {
+tasks.register('cleanCustomJRE') {
   group = "Build"
   description = "生成したカスタムJREを削除する"
 
@@ -260,7 +260,7 @@ test.dependsOn('spotlessApply')
 compileJava.dependsOn(['versionSet'])
 jacocoTestReport.dependsOn(['test'])
 
-dumpDependencies.dependsOn(['clearDependencies'])
+dumpDependencies.dependsOn(['cleanDependencies'])
 runApp.dependsOn(['dumpDependencies'])
 
-jlink.dependsOn(['clearCustomJRE'])
+jlink.dependsOn(['cleanCustomJRE'])

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,27 @@ plugins {
 
 apply plugin: 'org.junit.platform.gradle.plugin'
 
+// 変数定義
+
+// ソースコードに埋め込むコミットハッシュ値。デフォルト値はdevで、CIでのビルド時
+// に値を差し替える。
+def commitHash = 'dev'
+
+def VERSION_JAVA_FILE = 'Version.java'
+def SRC_FILE = 'template/' + VERSION_JAVA_FILE
+def DST_DIR = 'src/main/java/com/jiro4989/tkfm'
+def DST_FILE = DST_DIR + '/' + VERSION_JAVA_FILE
+
+def libDir = './lib'
+
+def appMods = [
+  'javafx.base',
+  'javafx.controls',
+  'javafx.swing',
+  'javafx.graphics',
+  'javafx.fxml',
+]
+
 repositories {
   mavenCentral()
 }
@@ -141,16 +162,10 @@ version = 'dev'
 if (project.hasProperty('CI_VERSION')) {
   version = CI_VERSION
 }
-def commitHash = 'dev'
 if (project.hasProperty('CI_COMMIT_HASH')) {
   commitHash = CI_COMMIT_HASH
 }
 
-def VERSION_JAVA_FILE = 'Version.java'
-def SRC_FILE = 'template/' + VERSION_JAVA_FILE
-
-def DST_DIR = 'src/main/java/com/jiro4989/tkfm'
-def DST_FILE = DST_DIR + '/' + VERSION_JAVA_FILE
 
 // Version.javaにバージョン番号とコミットハッシュを埋め込んでコピーする。
 //
@@ -165,8 +180,6 @@ task versionSet(type: Copy) {
   into DST_DIR
   expand(version: version, commitHash: commitHash)
 }
-
-def libDir = './lib'
 
 task clearDependencies {
   delete libDir
@@ -186,14 +199,6 @@ task dumpDependencies {
     }
   }
 }
-
-def appMods = [
-  'javafx.base',
-  'javafx.controls',
-  'javafx.swing',
-  'javafx.graphics',
-  'javafx.fxml',
-]
 
 task runApp(type: Exec) {
   commandLine 'java',
@@ -223,17 +228,13 @@ task jlink(type: Exec) {
 }
 
 /*
-実行順序の明示
-
-clean -> spotlessApply -+-> versionSet -> compileJava
-                        |
-                        +-> test -> jacocoTestReport
-
-clearDependencies -> dumpDependencies -> runApp
-
-clearCustomJRE -> jlink
-
-*/
+ 実行順序の明示
+ clean -> spotlessApply -+-> versionSet -> compileJava
+ |
+ +-> test -> jacocoTestReport
+ clearDependencies -> dumpDependencies -> runApp
+ clearCustomJRE -> jlink
+ */
 spotlessApply.dependsOn(['clean'])
 versionSet.dependsOn(['spotlessApply'])
 test.dependsOn('spotlessApply')

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ buildscript {
     }
   }
   dependencies {
-    classpath "org.openjfx:javafx-plugin:0.0.8"
     classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0'
 
     // Code Format
@@ -31,11 +30,13 @@ plugins {
   // Apply the application plugin to add support for building a CLI application.
   id 'application'
 
+  // JavaFX
+  id "org.openjfx.javafxplugin" version "0.0.10"
+
   // Code coverage
   id 'jacoco'
 }
 
-apply plugin: 'org.openjfx.javafxplugin'
 apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: "com.diffplug.spotless"
 apply plugin: "groovy"

--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ jacoco {
   applyTo junitPlatformTest
 }
 
-task junitPlatformJacocoReport(type: JacocoReport) {
+tasks.register('junitPlatformJacocoReport', JacocoReport) {
   sourceSets sourceSets.main
   executionData junitPlatformTest
 }
@@ -173,16 +173,17 @@ if (project.hasProperty('CI_COMMIT_HASH')) {
 // 環境変数を指定せずにビルドするとdevがデフォルトでセットされる。
 // CIでのビルド時にはタグ番号とコミットハッシュが埋め込まれる。
 // こうすることでタグ番号の二重管理を防ぐことができる。
-task versionSet(type: Copy) {
-  doFirst {
-    delete DST_FILE
-  }
+tasks.register('versionSet', Copy) {
   from SRC_FILE
   into DST_DIR
   expand(version: version, commitHash: commitHash)
+
+  doFirst {
+    delete DST_FILE
+  }
 }
 
-task clearDependencies {
+tasks.register('clearDependencies') {
   doLast {
     delete LIB_DIR
   }
@@ -191,7 +192,7 @@ task clearDependencies {
 // dependenciesで取得したjarファイルをlib配下にコピーする。
 //
 // runAppで実行するときにライブラリのパスを指定するために使用する。
-task dumpDependencies {
+tasks.register('dumpDependencies') {
   doLast {
     configurations.compileClasspath.each {
       def jarFile = it.absolutePath
@@ -203,7 +204,7 @@ task dumpDependencies {
   }
 }
 
-task runApp(type: Exec) {
+tasks.register('runApp', Exec) {
   doLast {
     commandLine 'java',
       '--module-path', LIB_DIR,
@@ -216,14 +217,14 @@ if (project.hasProperty('CI_JMODS_DIR')) {
   jmodsDir = CI_JMODS_DIR
 }
 
-task clearCustomJRE {
+tasks.register('clearCustomJRE') {
   doLast {
     delete CUSTOM_JRE_DIR
   }
 }
 
 // カスタムJREを作成する。
-task jlink(type: Exec) {
+tasks.register('jlink', Exec) {
   commandLine 'jlink',
     '--module-path', jmodsDir,
     '--add-modules', APP_MODS.join(','),

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,6 @@ buildscript {
   }
   dependencies {
     classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0'
-
-    // Code Format
-    classpath "com.diffplug.spotless:spotless-plugin-gradle:6.0.0"
   }
 }
 
@@ -33,12 +30,14 @@ plugins {
   // JavaFX
   id "org.openjfx.javafxplugin" version "0.0.10"
 
+  // Spotless for code formatting
+  id "com.diffplug.spotless" version "6.0.0"
+
   // Code coverage
   id 'jacoco'
 }
 
 apply plugin: 'org.junit.platform.gradle.plugin'
-apply plugin: "com.diffplug.spotless"
 apply plugin: "groovy"
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,15 @@ spotless {
   }
 }
 
+gradleLint {
+  rules = [
+    'all-dependency',
+    'duplicate-dependency-class'
+    // 勝手にあげられると心配なのでコメントアウト
+    // 'minimum-dependency-version'
+  ]
+}
+
 version = 'dev'
 if (project.hasProperty('CI_VERSION')) {
   version = CI_VERSION

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ plugins {
   id 'application'
 
   id 'jacoco'
+
+  id "nebula.lint" version "17.5.0"
 }
 
 apply plugin: 'org.openjfx.javafxplugin'

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ def DST_FILE = DST_DIR + '/' + VERSION_JAVA_FILE
 
 def LIB_DIR = './lib'
 
-def appMods = [
+def APP_MODS = [
   'javafx.base',
   'javafx.controls',
   'javafx.swing',
@@ -209,7 +209,7 @@ task runApp(type: Exec) {
   doLast {
     commandLine 'java',
       '--module-path', LIB_DIR,
-      '--add-modules', appMods.join(','),
+      '--add-modules', APP_MODS.join(','),
       '-jar', 'build/libs/tkfm-dev.jar'
   }
 }
@@ -229,7 +229,7 @@ task jlink(type: Exec) {
   doLast {
     commandLine 'jlink',
       '--module-path', jmodsDir,
-      '--add-modules', appMods.join(','),
+      '--add-modules', APP_MODS.join(','),
       '--compress=2',
       '--output', CUSTOM_JRE_DIR
   }

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ def appMods = [
   'javafx.fxml',
 ]
 
+def jmodsDir = './jmods/javafx-jmods-11.0.2'
+def customJREDir = 'jre'
+
 repositories {
   mavenCentral()
 }
@@ -210,9 +213,6 @@ task runApp(type: Exec) {
       '-jar', 'build/libs/tkfm-dev.jar'
   }
 }
-
-def jmodsDir = './jmods/javafx-jmods-11.0.2'
-def customJREDir = 'jre'
 
 if (project.hasProperty('CI_JMODS_DIR')) {
   jmodsDir = CI_JMODS_DIR

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ plugins {
   // Apply the java plugin to add support for Java
   id 'java'
 
+  // Apply the gradle plugin to add support for Gradle
+  id 'groovy'
+
   // Apply the application plugin to add support for building a CLI application.
   id 'application'
 
@@ -38,7 +41,6 @@ plugins {
 }
 
 apply plugin: 'org.junit.platform.gradle.plugin'
-apply plugin: "groovy"
 
 repositories {
   mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ def SRC_FILE = 'template/' + VERSION_JAVA_FILE
 def DST_DIR = 'src/main/java/com/jiro4989/tkfm'
 def DST_FILE = DST_DIR + '/' + VERSION_JAVA_FILE
 
-def libDir = './lib'
+def LIB_DIR = './lib'
 
 def appMods = [
   'javafx.base',
@@ -182,7 +182,7 @@ task versionSet(type: Copy) {
 }
 
 task clearDependencies {
-  delete libDir
+  delete LIB_DIR
 }
 
 // dependenciesで取得したjarファイルをlib配下にコピーする。
@@ -194,7 +194,7 @@ task dumpDependencies {
       def jarFile = it.absolutePath
       copy {
         from jarFile
-        into libDir
+        into LIB_DIR
       }
     }
   }
@@ -202,7 +202,7 @@ task dumpDependencies {
 
 task runApp(type: Exec) {
   commandLine 'java',
-    '--module-path', libDir,
+    '--module-path', LIB_DIR,
     '--add-modules', appMods.join(','),
     '-jar', 'build/libs/tkfm-dev.jar'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,6 @@ plugins {
   id 'application'
 
   id 'jacoco'
-
-  id "nebula.lint" version "17.5.0"
 }
 
 apply plugin: 'org.openjfx.javafxplugin'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ plugins {
   // Apply the application plugin to add support for building a CLI application.
   id 'application'
 
+  // Code coverage
   id 'jacoco'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -140,15 +140,6 @@ spotless {
   }
 }
 
-gradleLint {
-  rules = [
-    'all-dependency',
-    'duplicate-dependency-class'
-    // 勝手にあげられると心配なのでコメントアウト
-    // 'minimum-dependency-version'
-  ]
-}
-
 version = 'dev'
 if (project.hasProperty('CI_VERSION')) {
   version = CI_VERSION

--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,9 @@ task versionSet(type: Copy) {
 }
 
 task clearDependencies {
-  delete LIB_DIR
+  doLast {
+    delete LIB_DIR
+  }
 }
 
 // dependenciesで取得したjarファイルをlib配下にコピーする。
@@ -201,10 +203,12 @@ task dumpDependencies {
 }
 
 task runApp(type: Exec) {
-  commandLine 'java',
-    '--module-path', LIB_DIR,
-    '--add-modules', appMods.join(','),
-    '-jar', 'build/libs/tkfm-dev.jar'
+  doLast {
+    commandLine 'java',
+      '--module-path', LIB_DIR,
+      '--add-modules', appMods.join(','),
+      '-jar', 'build/libs/tkfm-dev.jar'
+  }
 }
 
 def jmodsDir = './jmods/javafx-jmods-11.0.2'
@@ -215,16 +219,20 @@ if (project.hasProperty('CI_JMODS_DIR')) {
 }
 
 task clearCustomJRE {
-  delete customJREDir
+  doLast {
+    delete customJREDir
+  }
 }
 
 // カスタムJREを作成する。
 task jlink(type: Exec) {
-  commandLine 'jlink',
-    '--module-path', jmodsDir,
-    '--add-modules', appMods.join(','),
-    '--compress=2',
-    '--output', customJREDir
+  doLast {
+    commandLine 'jlink',
+      '--module-path', jmodsDir,
+      '--add-modules', appMods.join(','),
+      '--compress=2',
+      '--output', customJREDir
+  }
 }
 
 /*

--- a/build.gradle
+++ b/build.gradle
@@ -224,13 +224,11 @@ task clearCustomJRE {
 
 // カスタムJREを作成する。
 task jlink(type: Exec) {
-  doLast {
-    commandLine 'jlink',
-      '--module-path', jmodsDir,
-      '--add-modules', APP_MODS.join(','),
-      '--compress=2',
-      '--output', CUSTOM_JRE_DIR
-  }
+  commandLine 'jlink',
+    '--module-path', jmodsDir,
+    '--add-modules', APP_MODS.join(','),
+    '--compress=2',
+    '--output', CUSTOM_JRE_DIR
 }
 
 /*


### PR DESCRIPTION
[Gradle best practice](https://docs.gradle.org/current/userguide/authoring_maintainable_build_scripts.html)を読んだ。

以下の変更を加えた。

- doLastを明示的記述
- 変数の定義場所を一箇所に集約
- javafxの依存性のバージョン指定に変数を使わないよう
- implementation, testImplementationの引数の書き方を統一
- buildscriptに書く必要のなかったものをpluginに移動
- 定数はUPPER\_SCAKE\_CASEで統一
- 依存性を一箇所でまとめて定義するように変更
- タスクの命名を変更
- タスクに group, description を追加
- `tasks.register` を使うように変更