### PR TITLE
chore: リファクタリング

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -275,8 +275,9 @@ tasks.register('jlink', Exec) {
 spotlessApply.dependsOn(['clean'])
 versionSet.dependsOn(['spotlessApply'])
 test.dependsOn('spotlessApply')
-compileJava.dependsOn(['versionSet'])
-compileKotlin.dependsOn(['versionSet'])
+processResources.dependsOn(['versionSet'])
+compileJava.dependsOn(['processResources'])
+compileKotlin.dependsOn(['processResources'])
 jacocoTestReport.dependsOn(['test'])
 
 dumpDependencies.dependsOn(['cleanDependencies'])

--- a/src/main/kotlin/com/jiro4989/tkfm/controller/MainViewController.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/controller/MainViewController.kt
@@ -132,7 +132,7 @@ config/image_format.xmlファイルを手動で書き換えるなどして、
     tileImage = TileImageModel(imageFormat)
 
     // bindigns
-    val pos = cropImage.position
+    val pos = cropImage.croppingPosition
     val rowCount = selectedImageFormat.rowProperty
     val colCount = selectedImageFormat.colProperty
 
@@ -445,7 +445,7 @@ config/image_format.xmlファイルを手動で書き換えるなどして、
   private fun setCropSizeWithDialog() {
     val ci =
         cropImage.let {
-          val pos = it.position
+          val pos = it.croppingPosition
           val stage = CropImageStage(pos.x, pos.y, it.scaleProperty.value)
           stage.showAndWait()
           stage

--- a/src/main/kotlin/com/jiro4989/tkfm/controller/MainViewController.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/controller/MainViewController.kt
@@ -127,7 +127,7 @@ config/image_format.xmlファイルを手動で書き換えるなどして、
     val selectedImageFormat = imageFormat.selectedImageFormat
     val rect = selectedImageFormat.rectangle
 
-    cropImage = CroppingImageModel(rectangle = rect)
+    cropImage = CroppingImageModel(croppingRectangle = rect)
     imageFiles = ImageFilesModel(cropImage)
     tileImage = TileImageModel(imageFormat)
 

--- a/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
@@ -178,14 +178,14 @@ data class CroppingImageModel(
   }
 
   fun setScale(scale: Double) {
-    val MIN_SCALE = 20.0
-    val MAX_SCALE = 200.0
+    val minScale = 20.0
+    val maxScale = 200.0
     var scale2 = scale
 
-    if (scale2 < MIN_SCALE) {
-      scale2 = MIN_SCALE
-    } else if (MAX_SCALE < scale2) {
-      scale2 = MAX_SCALE
+    if (scale2 < minScale) {
+      scale2 = minScale
+    } else if (maxScale < scale2) {
+      scale2 = maxScale
     }
 
     scaleProperty.set(scale2)

--- a/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
@@ -98,6 +98,7 @@ data class CroppingImageModel(
     return wImg
   }
 
+  /** トリミング座標を x, y の座標に変更し、トリミング画像を更新する。 座標が不正な範囲外の場合は下限値、上限値に変更して設定するため、異常な範囲指定に対して安全である。 */
   fun move(x: Double = croppingPosition.x, y: Double = croppingPosition.y) {
     val bImg = imageProperty.get()
     val s = scaleProperty.get() / 100
@@ -124,13 +125,10 @@ data class CroppingImageModel(
   fun moveLeft(n: Double) = move(x = croppingPosition.x - n)
   fun moveRight(n: Double) = move(x = croppingPosition.x + n)
 
-  /** Centering */
+  /** トリミング座標を指定して、画像をトリミングする。 座標はマウスでの設定を想定しており、座標はトリミング矩形の中央として解釈する。 */
   fun moveByMouse(x: Double, y: Double) {
-    val w = croppingRectangle.width
-    val h = croppingRectangle.height
-    val xx = x - w / 2
-    val yy = y - h / 2
-    move(xx, yy)
+    val (width, height) = croppingRectangle / 2.0
+    move(x - width, y - height)
   }
 
   fun clearImage() {

--- a/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
@@ -42,7 +42,7 @@ data class CroppingImageModel(
     val scaleProperty: DoubleProperty = SimpleDoubleProperty(100.0),
 
     /** トリミング座標 */
-    val position: PositionModel = PositionModel(0.0, 0.0),
+    val croppingPosition: PositionModel = PositionModel(0.0, 0.0),
     /** トリミング画像の矩形 */
     val rectangle: RectangleModel
 ) {
@@ -52,8 +52,8 @@ data class CroppingImageModel(
     val scale = scaleProperty.get() / 100
 
     // 座標と矩形にスケールをかけてトリミングサイズを調整
-    var x = position.x / scale
-    var y = position.y / scale
+    var x = croppingPosition.x / scale
+    var y = croppingPosition.y / scale
     val width = rectangle.width / scale
     val height = rectangle.height / scale
 
@@ -79,8 +79,8 @@ data class CroppingImageModel(
 
   fun cropByBufferedImage(): Image {
     val scale = scaleProperty.get() / 100
-    var x = position.x.toInt()
-    var y = position.y.toInt()
+    var x = croppingPosition.x.toInt()
+    var y = croppingPosition.y.toInt()
     var width = rectangle.width.toInt()
     var height = rectangle.height.toInt()
 
@@ -105,7 +105,7 @@ data class CroppingImageModel(
     return wImg
   }
 
-  fun move(x: Double = position.x, y: Double = position.y) {
+  fun move(x: Double = croppingPosition.x, y: Double = croppingPosition.y) {
     val bImg = imageProperty.get()
     val s = scaleProperty.get() / 100
     val w = bImg.width
@@ -121,32 +121,32 @@ data class CroppingImageModel(
     if (xx < 0) xx = 0.0
     if (yy < 0) yy = 0.0
 
-    position.x = xx
-    position.y = yy
+    croppingPosition.x = xx
+    croppingPosition.y = yy
     croppedImageProperty.set(crop())
   }
 
   fun moveUp(n: Double) {
-    val x = position.x
-    val y = position.y - n
+    val x = croppingPosition.x
+    val y = croppingPosition.y - n
     move(x, y)
   }
 
   fun moveRight(n: Double) {
-    val x = position.x + n
-    val y = position.y
+    val x = croppingPosition.x + n
+    val y = croppingPosition.y
     move(x, y)
   }
 
   fun moveDown(n: Double) {
-    val x = position.x
-    val y = position.y + n
+    val x = croppingPosition.x
+    val y = croppingPosition.y + n
     move(x, y)
   }
 
   fun moveLeft(n: Double) {
-    val x = position.x - n
-    val y = position.y
+    val x = croppingPosition.x - n
+    val y = croppingPosition.y
     move(x, y)
   }
 

--- a/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
@@ -61,11 +61,6 @@ data class CroppingImageModel(
 
     val img = imageProperty.get()
 
-    // 画像サイズ0は通常起こり得ないはず
-    if (img.width <= 0 || img.height <= 0) {
-      return croppedImageProperty.get()
-    }
-
     // 座標に矩形幅を足した値が画像全体の幅より大きくなってはいけない
     if (img.width < x + width || img.height < y + height) {
       return croppedImageProperty.get()

--- a/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
@@ -44,7 +44,7 @@ data class CroppingImageModel(
     /** トリミング座標 */
     val croppingPosition: PositionModel = PositionModel(0.0, 0.0),
     /** トリミング画像の矩形 */
-    val rectangle: RectangleModel
+    val croppingRectangle: RectangleModel
 ) {
 
   fun crop(): Image {
@@ -54,8 +54,8 @@ data class CroppingImageModel(
     // 座標と矩形にスケールをかけてトリミングサイズを調整
     var x = croppingPosition.x / scale
     var y = croppingPosition.y / scale
-    val width = rectangle.width / scale
-    val height = rectangle.height / scale
+    val width = croppingRectangle.width / scale
+    val height = croppingRectangle.height / scale
 
     // 0未満の座標はNGなので0で上書きして調整
     if (x < 0) x = 0.0
@@ -81,8 +81,8 @@ data class CroppingImageModel(
     val scale = scaleProperty.get() / 100
     var x = croppingPosition.x.toInt()
     var y = croppingPosition.y.toInt()
-    var width = rectangle.width.toInt()
-    var height = rectangle.height.toInt()
+    var width = croppingRectangle.width.toInt()
+    var height = croppingRectangle.height.toInt()
 
     val bImg = SwingFXUtils.fromFXImage(imageProperty.get(), null)
     val scaledImg = scaledImage(bImg, scale)
@@ -110,8 +110,8 @@ data class CroppingImageModel(
     val s = scaleProperty.get() / 100
     val w = bImg.width
     val h = bImg.height
-    val rectWidth = rectangle.width
-    val rectHeight = rectangle.height
+    val rectWidth = croppingRectangle.width
+    val rectHeight = croppingRectangle.height
 
     var xx = x
     var yy = y
@@ -152,8 +152,8 @@ data class CroppingImageModel(
 
   /** Centering */
   fun moveByMouse(x: Double, y: Double) {
-    val w = rectangle.width
-    val h = rectangle.height
+    val w = croppingRectangle.width
+    val h = croppingRectangle.height
     val xx = x - w / 2
     val yy = y - h / 2
     move(xx, yy)

--- a/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
@@ -105,7 +105,7 @@ data class CroppingImageModel(
     return wImg
   }
 
-  fun move(x: Double, y: Double) {
+  fun move(x: Double = position.x, y: Double = position.y) {
     val bImg = imageProperty.get()
     val s = scaleProperty.get() / 100
     val w = bImg.width
@@ -124,12 +124,6 @@ data class CroppingImageModel(
     position.x = xx
     position.y = yy
     croppedImageProperty.set(crop())
-  }
-
-  fun move() {
-    val x = position.x
-    val y = position.y
-    move(x, y)
   }
 
   fun moveUp(n: Double) {

--- a/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
@@ -52,8 +52,7 @@ data class CroppingImageModel(
     val scale = scaleProperty.get() / 100
 
     // 座標と矩形にスケールをかけてトリミングサイズを調整
-    var x = croppingPosition.x / scale
-    var y = croppingPosition.y / scale
+    var (x, y) = croppingPosition / scale
     val width = croppingRectangle.width / scale
     val height = croppingRectangle.height / scale
 

--- a/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
@@ -119,29 +119,10 @@ data class CroppingImageModel(
     croppedImageProperty.set(crop())
   }
 
-  fun moveUp(n: Double) {
-    val x = croppingPosition.x
-    val y = croppingPosition.y - n
-    move(x, y)
-  }
-
-  fun moveRight(n: Double) {
-    val x = croppingPosition.x + n
-    val y = croppingPosition.y
-    move(x, y)
-  }
-
-  fun moveDown(n: Double) {
-    val x = croppingPosition.x
-    val y = croppingPosition.y + n
-    move(x, y)
-  }
-
-  fun moveLeft(n: Double) {
-    val x = croppingPosition.x - n
-    val y = croppingPosition.y
-    move(x, y)
-  }
+  fun moveUp(n: Double) = move(y = croppingPosition.y - n)
+  fun moveDown(n: Double) = move(y = croppingPosition.y + n)
+  fun moveLeft(n: Double) = move(x = croppingPosition.x - n)
+  fun moveRight(n: Double) = move(x = croppingPosition.x + n)
 
   /** Centering */
   fun moveByMouse(x: Double, y: Double) {

--- a/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/CroppingImageModel.kt
@@ -53,8 +53,7 @@ data class CroppingImageModel(
 
     // 座標と矩形にスケールをかけてトリミングサイズを調整
     var (x, y) = croppingPosition / scale
-    val width = croppingRectangle.width / scale
-    val height = croppingRectangle.height / scale
+    val (width, height) = croppingRectangle / scale
 
     // 0未満の座標はNGなので0で上書きして調整
     if (x < 0) x = 0.0

--- a/src/main/kotlin/com/jiro4989/tkfm/model/ImageFormatConfigModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/ImageFormatConfigModel.kt
@@ -54,8 +54,8 @@ data class ImageFormatConfigModel(
     if (index < 0) return
     if (max <= index) return
     val fmt = total.get(index)
-    selectedImageFormat.rowProperty.set(fmt.rowProperty.get())
-    selectedImageFormat.colProperty.set(fmt.colProperty.get())
+    selectedImageFormat.row = fmt.row
+    selectedImageFormat.col = fmt.col
     selectedImageFormat.rectangle.widthProperty.set(fmt.rectangle.width)
     selectedImageFormat.rectangle.heightProperty.set(fmt.rectangle.height)
   }
@@ -181,8 +181,8 @@ data class ImageFormatConfigModel(
       val item = document.createElement("imageFormat")
       val rect = fmt.rectangle
       item.setAttribute("name", fmt.name)
-      item.setAttribute("row", fmt.rowProperty.get().toString())
-      item.setAttribute("col", fmt.colProperty.get().toString())
+      item.setAttribute("row", fmt.row.toString())
+      item.setAttribute("col", fmt.col.toString())
       item.setAttribute("tileWidth", "" + rect.widthProperty.get().toInt().toString())
       item.setAttribute("tileHeight", "" + rect.heightProperty.get().toInt().toString())
       root.appendChild(item)

--- a/src/main/kotlin/com/jiro4989/tkfm/model/ImageFormatModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/ImageFormatModel.kt
@@ -13,6 +13,13 @@ data class ImageFormatModel(
     /** 1タイルあたりの矩形 */
     val rectangle: RectangleModel
 ) {
+  var row
+    get() = rowProperty.get()
+    set(value) = rowProperty.set(value)
+  var col
+    get() = colProperty.get()
+    set(value) = colProperty.set(value)
+
   constructor(name: String, row: Int, col: Int, rect: RectangleModel) : this(
       name, SimpleIntegerProperty(row), SimpleIntegerProperty(col), rect)
 }

--- a/src/main/kotlin/com/jiro4989/tkfm/model/PositionModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/PositionModel.kt
@@ -12,4 +12,6 @@ data class PositionModel(val xProperty: DoubleProperty, val yProperty: DoublePro
     set(value) = yProperty.set(value)
   constructor() : this(DP(0.0), DP(0.0))
   constructor(x: Double, y: Double) : this(DP(x), DP(y))
+
+  operator fun div(scale: Double) = Pair(x / scale, y / scale)
 }

--- a/src/main/kotlin/com/jiro4989/tkfm/model/PropertiesModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/PropertiesModel.kt
@@ -41,35 +41,31 @@ data class WindowPropertiesModel(
       return
     }
 
-    try {
-      FileInputStream(file).use { stream: InputStream ->
-        prop.load(InputStreamReader(stream, "UTF-8"))
-        prop.getProperty("x")?.let {
-          if (!it.isNullOrEmpty()) {
-            x = it.toDouble()
-          }
-        }
-
-        prop.getProperty("y")?.let {
-          if (!it.isNullOrEmpty()) {
-            y = it.toDouble()
-          }
-        }
-
-        prop.getProperty("width")?.let {
-          if (!it.isNullOrEmpty()) {
-            width = it.toDouble()
-          }
-        }
-
-        prop.getProperty("height")?.let {
-          if (!it.isNullOrEmpty()) {
-            height = it.toDouble()
-          }
+    FileInputStream(file).use { stream: InputStream ->
+      prop.load(InputStreamReader(stream, "UTF-8"))
+      prop.getProperty("x")?.let {
+        if (!it.isNullOrEmpty()) {
+          x = it.toDouble()
         }
       }
-    } catch (e: IOException) {
-      e.printStackTrace()
+
+      prop.getProperty("y")?.let {
+        if (!it.isNullOrEmpty()) {
+          y = it.toDouble()
+        }
+      }
+
+      prop.getProperty("width")?.let {
+        if (!it.isNullOrEmpty()) {
+          width = it.toDouble()
+        }
+      }
+
+      prop.getProperty("height")?.let {
+        if (!it.isNullOrEmpty()) {
+          height = it.toDouble()
+        }
+      }
     }
   }
 
@@ -104,14 +100,10 @@ data class ChoosedFilePropertiesModel(
       return
     }
 
-    try {
-      FileInputStream(file).use { stream: InputStream ->
-        prop.load(InputStreamReader(stream, "UTF-8"))
-        openedFile = readFileFromProperties(prop, "opened_file_dir", "opened_file_file")
-        savedFile = readFileFromProperties(prop, "saved_file_dir", "saved_file_file")
-      }
-    } catch (e: IOException) {
-      e.printStackTrace()
+    FileInputStream(file).use { stream: InputStream ->
+      prop.load(InputStreamReader(stream, "UTF-8"))
+      openedFile = readFileFromProperties(prop, "opened_file_dir", "opened_file_file")
+      savedFile = readFileFromProperties(prop, "saved_file_dir", "saved_file_file")
     }
   }
 

--- a/src/main/kotlin/com/jiro4989/tkfm/model/PropertiesModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/PropertiesModel.kt
@@ -95,6 +95,11 @@ data class ChoosedFilePropertiesModel(
     var openedFile: File? = null,
     var savedFile: File? = null
 ) : PropertiesInterface {
+  private val propertyKeyOpenedFileDir = "opened_file_dir"
+  private val propertyKeyOpenedFileFile = "opened_file_file"
+  private val propertyKeySavedFileDir = "saved_file_dir"
+  private val propertyKeySavedFileFile = "saved_file_file"
+
   override fun load() {
     if (!file.exists()) {
       return
@@ -102,8 +107,8 @@ data class ChoosedFilePropertiesModel(
 
     FileInputStream(file).use { stream: InputStream ->
       prop.load(InputStreamReader(stream, "UTF-8"))
-      openedFile = readFileFromProperties(prop, "opened_file_dir", "opened_file_file")
-      savedFile = readFileFromProperties(prop, "saved_file_dir", "saved_file_file")
+      openedFile = readFileFromProperties(prop, propertyKeyOpenedFileDir, propertyKeyOpenedFileFile)
+      savedFile = readFileFromProperties(prop, propertyKeySavedFileDir, propertyKeySavedFileFile)
     }
   }
 
@@ -111,13 +116,13 @@ data class ChoosedFilePropertiesModel(
     file.getParentFile().mkdirs()
 
     openedFile?.let {
-      prop.setProperty("opened_file_dir", it.parentFile.absolutePath)
-      prop.setProperty("opened_file_file", it.name)
+      prop.setProperty(propertyKeyOpenedFileDir, it.parentFile.absolutePath)
+      prop.setProperty(propertyKeyOpenedFileFile, it.name)
     }
 
     savedFile?.let {
-      prop.setProperty("saved_file_dir", it.parentFile.absolutePath)
-      prop.setProperty("saved_file_file", it.name)
+      prop.setProperty(propertyKeySavedFileDir, it.parentFile.absolutePath)
+      prop.setProperty(propertyKeySavedFileFile, it.name)
     }
 
     try {

--- a/src/main/kotlin/com/jiro4989/tkfm/model/PropertiesModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/PropertiesModel.kt
@@ -1,7 +1,6 @@
 package com.jiro4989.tkfm.model
 
 import java.io.*
-import java.util.Optional
 import java.util.Properties
 
 private val configDir = "config"

--- a/src/main/kotlin/com/jiro4989/tkfm/model/RectangleModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/RectangleModel.kt
@@ -12,4 +12,6 @@ data class RectangleModel(val widthProperty: DoubleProperty, val heightProperty:
     set(value) = heightProperty.set(value)
 
   constructor(w: Double, h: Double) : this(DP(w), DP(h))
+
+  operator fun div(scale: Double) = Pair(width / scale, height / scale)
 }

--- a/src/main/kotlin/com/jiro4989/tkfm/model/TileImageModel.kt
+++ b/src/main/kotlin/com/jiro4989/tkfm/model/TileImageModel.kt
@@ -34,11 +34,7 @@ class TileImageModel {
     draw()
   }
 
-  fun bulkInsert(images: List<Image>) {
-    bulkInsert(images, 0)
-  }
-
-  fun bulkInsert(images: List<Image>, startIndex: Int) {
+  fun bulkInsert(images: List<Image>, startIndex: Int = 0) {
     val rowCount = getRow()
     val colCount = getCol()
     val size = images.size

--- a/src/test/kotlin/com/jiro4989/tkfm/model/CroppingImageModelTest.kt
+++ b/src/test/kotlin/com/jiro4989/tkfm/model/CroppingImageModelTest.kt
@@ -95,7 +95,7 @@ class CroppingImageModelTest {
       "left" -> c.moveLeft(moveWidth)
     }
 
-    pos = c.position
+    pos = c.croppingPosition
     assertEquals(wantX, pos.x)
     assertEquals(wantY, pos.y)
     assertEquals(20.0, c.croppedImageProperty.get().width)
@@ -113,7 +113,7 @@ class CroppingImageModelTest {
     val scale = 100.0
     val c = crop(img, pos, rect, scale)
     c.moveByMouse(x, y)
-    pos = c.position
+    pos = c.croppingPosition
     assertEquals(wantX, pos.x)
     assertEquals(wantY, pos.y)
   }
@@ -168,7 +168,7 @@ class CroppingImageModelTest {
     val rect = RectangleModel(20.0, 20.0)
     val scale = 100.0
     val c = crop(img, pos, rect, scale)
-    val p = c.position
+    val p = c.croppingPosition
 
     assertEquals(30.0, p.x)
     assertEquals(50.0, p.y)
@@ -193,7 +193,7 @@ class CroppingImageModelTest {
   private fun crop(img: Image, pos: PositionModel, rect: RectangleModel, scale: Double) =
       CroppingImageModel(
           imageProperty = SimpleObjectProperty(img),
-          position = pos,
+          croppingPosition = pos,
           rectangle = rect,
           scaleProperty = SimpleDoubleProperty(scale))
 }

--- a/src/test/kotlin/com/jiro4989/tkfm/model/CroppingImageModelTest.kt
+++ b/src/test/kotlin/com/jiro4989/tkfm/model/CroppingImageModelTest.kt
@@ -183,7 +183,7 @@ class CroppingImageModelTest {
     val rect = RectangleModel(20.0, 30.0)
     val scale = 100.0
     val c = crop(img, pos, rect, scale)
-    val r = c.rectangle
+    val r = c.croppingRectangle
 
     assertEquals(20.0, r.width)
     assertEquals(30.0, r.height)
@@ -194,6 +194,6 @@ class CroppingImageModelTest {
       CroppingImageModel(
           imageProperty = SimpleObjectProperty(img),
           croppingPosition = pos,
-          rectangle = rect,
+          croppingRectangle = rect,
           scaleProperty = SimpleDoubleProperty(scale))
 }

--- a/src/test/kotlin/com/jiro4989/tkfm/model/ImageFilesModelTest.kt
+++ b/src/test/kotlin/com/jiro4989/tkfm/model/ImageFilesModelTest.kt
@@ -60,6 +60,6 @@ class ImageFilesModelTest {
     i.select(index)
   }
 
-  private fun crop() = CroppingImageModel(rectangle = RectangleModel(144.0, 144.0))
+  private fun crop() = CroppingImageModel(croppingRectangle = RectangleModel(144.0, 144.0))
   private fun resourcePath(path: String) = this.javaClass.getResource(path).getPath()
 }


### PR DESCRIPTION
- 汎用的すぎるプロパティ名の変更
- メソッドのオーバーロードて実装してた箇所を名前付き引数を使うように変更
- position, rectangleの拡縮演算をプロパティ個別に取得して演算していた箇所を、複数プロパティまとめて演算してPairで返却するoperatorの追加
  - 計算忘れ、プロパティ指定誤りを抑止できる
- 到達し得ない条件分岐を削除