### PR TITLE
chore: アプリケーションのバージョン書式を変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,14 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           java-package: jdk
           architecture: x64
+
+      - name: Set build version information
+        run: |
+          echo ORG_GRADLE_PROJECT_CI_VERSION="${GITHUB_REF##*/v}" >> $GITHUB_ENV
+          echo ORG_GRADLE_PROJECT_CI_COMMIT_HASH="$(git rev-parse HEAD)" >> $GITHUB_ENV
+
       - name: Build
-        run: >
-          ORG_GRADLE_PROJECT_CI_VERSION="${GITHUB_REF##*/}"
-          ORG_GRADLE_PROJECT_CI_COMMIT_HASH="$(git rev-parse HEAD)"
-          ./gradlew build -x test
+        run: ./gradlew build -x test
 
       - name: Create artifact
         run: >
@@ -58,7 +61,7 @@ jobs:
           ARCHIVE_CMD="${{ matrix.archive_cmd }}"
           ARTIFACT_EXT="${{ matrix.artifact_ext }}"
           ENTRYPOINT_SCRIPT_EXT="${{ matrix.entrypoint_script_ext }}"
-          VERSION="${GITHUB_REF##*/}"
+          VERSION="${ORG_GRADLE_PROJECT_CI_VERSION}"
           ./script/create_artifact.sh
 
       - name: Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
   build-artifact:
     runs-on: ${{ matrix.os }}
     env:
-      VERSION: ci
+      VERSION: 0.0.0-SNAPSHOT
     strategy:
       matrix:
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,11 +76,14 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           java-package: jdk
           architecture: x64
+
+      - name: Set build version information
+        run: |
+          echo ORG_GRADLE_PROJECT_CI_VERSION="${VERSION}" >> $GITHUB_ENV
+          echo ORG_GRADLE_PROJECT_CI_COMMIT_HASH="$(git rev-parse HEAD)" >> $GITHUB_ENV
+
       - name: Build
-        run: >
-          ORG_GRADLE_PROJECT_CI_VERSION="${VERSION}"
-          ORG_GRADLE_PROJECT_CI_COMMIT_HASH="$(git rev-parse HEAD)"
-          ./gradlew build -x test
+        run: ./gradlew build -x test
 
       - name: Create artifact
         run: >

--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ spotless {
   }
 }
 
-version = 'dev'
+version = '0.0.0-SNAPSHOT'
 if (project.hasProperty('CI_VERSION')) {
   version = CI_VERSION
 }

--- a/build.gradle
+++ b/build.gradle
@@ -243,7 +243,7 @@ tasks.register('runApp', Exec) {
   commandLine 'java',
     '--module-path', LIB_DIR,
     '--add-modules', APP_MODS.join(','),
-    '-jar', 'build/libs/tkfm-dev.jar'
+    '-jar', "build/libs/tkfm-${version}.jar"
 }
 
 if (project.hasProperty('CI_JMODS_DIR')) {

--- a/script/build_for_linux.sh
+++ b/script/build_for_linux.sh
@@ -2,4 +2,4 @@
 
 set -eux
 
-APP_NAME="tkfm" JAVAFX_VERSION=16 OS_NAME=linux ARCHIVE_CMD="tar czf" ARTIFACT_EXT=.tar.gz ENTRYPOINT_SCRIPT_EXT="" VERSION="dev" ./script/create_artifact.sh
+APP_NAME="tkfm" JAVAFX_VERSION=16 OS_NAME=linux ARCHIVE_CMD="tar czf" ARTIFACT_EXT=.tar.gz ENTRYPOINT_SCRIPT_EXT="" VERSION="0.0.0-SNAPSHOT" ./script/create_artifact.sh

--- a/src/main/resources/com/jiro4989/tkfm/properties/application.properties
+++ b/src/main/resources/com/jiro4989/tkfm/properties/application.properties
@@ -1,2 +1,2 @@
-version = dev
+version = 0.0.0-SNAPSHOT
 commithash = dev


### PR DESCRIPTION
Javaのプロジェクトではバージョン番号の命名は以下が一般的

- 開発版 : n.n.n-SNAPSHOT
- 正式リリース : n.n.n

現状、開発版に dev, ci などを割り振っていて、正式リリースでは vN.N.N になっているのが気になるので変更する。

ちなみに、 module-info.java を使う構成に変更しようとしたときに気付いた。
バージョン番号の書式がこのどちらかの書式に従って無いと gradle がコケる。